### PR TITLE
Fix tests and remove forced absolute paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@ var through = require('through2'),
     async   = require('async'),
     fs      = require('fs'),
     crypto  = require('crypto'),
-    extname = require('path').extname;
+    extname = require('path').extname,
+    gutil   = require('gulp-util');
 
 var PLUGIN_NAME = 'gulp-css-image-hash';
 
@@ -38,11 +39,6 @@ function cssImageHash(webPath, includeFileExtensions) {
                 if (path[0] == '"' || path[0] == "'") {
                     path = path.slice(1).slice(0, -1);
                 }
-
-                //If the path does not start with a '/', add it
-                if (path[0] != '/') {
-                    path = '/' + path;
-                }
                 
                 pairs.push([curValue, path]);
             });
@@ -56,6 +52,10 @@ function cssImageHash(webPath, includeFileExtensions) {
                     if(includeFileExtensions.indexOf(extension) < 0) {
                         return callback();   
                     }
+                }
+
+                if (path.substr(0, 4) == 'data') {
+                    return callback();
                 }
                 
                 if (typeof(webPath) == 'function') {
@@ -83,7 +83,7 @@ function cssImageHash(webPath, includeFileExtensions) {
                 });
                 
                 file.on('error', function(error) {
-                    console.log(error.message);
+                    gutil.log('gulp-css-image-hash: Skipping ' + path);
                     callback();
                 });
             }, function (err) {

--- a/package.json
+++ b/package.json
@@ -15,9 +15,11 @@
   "license": "MIT",
   "dependencies": {
     "async": "^0.9.0",
+    "gulp-util": "^3.0.8",
     "through2": "*"
   },
   "devDependencies": {
+    "mocha": "^3.2.0",
     "should": "^4.3.0"
   }
 }

--- a/test/main.js
+++ b/test/main.js
@@ -48,6 +48,21 @@ describe('gulp-css-image-hash', function() {
                 done();
             });
         });
+
+        it('should ignore data urls', function(done) {
+            var fakeFile = new File({
+                contents: new Buffer('body { background: url(data:image/gif;base64,R0lGO); }')
+            });
+
+            var hasher = imagehash('test/examples/');
+            hasher.write(fakeFile);
+
+            hasher.once('data', function(file) {
+                assert(file.isBuffer());
+                assert.equal(file.contents.toString(), 'body { background: url(data:image/gif;base64,R0lGO); }');
+                done();
+            });
+        });
         
         it('should update resolvable resource', function(done) {
             var fakeFile = new File({


### PR DESCRIPTION
Remove forcing paths to be absolute.
Change console.log to gulp log
Skip passing data urls to modifier